### PR TITLE
Update GitHub Actions cache action

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     # Use GitHub Actions' cache to shorten build times and decrease load on servers
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}


### PR DESCRIPTION
The previous version of [actions/cache](https://github.com/marketplace/actions/cache) is deprecated, therefore any workflows using that version will fail.